### PR TITLE
Fix an issue where keyChannel for loop hangs

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -12,6 +12,7 @@ type Suggestion struct {
 	BlackListed    bool   `json:"blackListed"`
 	XcatOnly       bool   `json:"xcatOnly"`
 }
+
 type KeywordSuggestions struct {
 	Alias             string       `json:"alias"`
 	Prefix            string       `json:"prefix"`
@@ -25,4 +26,8 @@ type KeywordSuggestions struct {
 type Keyword struct {
 	Keyword          string
 	TotalResultCount int64
+}
+
+type Context struct {
+	KeywordsFound int
 }


### PR DESCRIPTION
Because we cannot know how many suggestions there will be prior to starting the search, we need to keep some sort of a count record and terminate the `keyChannel` suggestions `for` loop when no more suggestions are found.

This change passes a context structure to each `requestKeyWords()` goroutine and uses a mutex to sync the inc/dec of the total keywords count.